### PR TITLE
Fix multi where clause custom field bug

### DIFF
--- a/src/main/java/com/sethhaskellcondie/thegamepensieveapi/domain/Keychain.java
+++ b/src/main/java/com/sethhaskellcondie/thegamepensieveapi/domain/Keychain.java
@@ -37,8 +37,8 @@ public final class Keychain {
         );
     }
 
-    //This is used to construct the filter objects into SQL, this function should return the table alias used in the base query of that entities' repository
-    //The table alias for custom fields is always 'fields' and for custom field values is always 'values'
+    // This is used to construct the filter objects into SQL, this function should return the table alias used in the base query of that entities' repository.
+    // When custom field filters are present, each filter gets an indexed alias pair: fields1/values1, fields2/values2, etc.
     public static String getTableAliasByKey(String key) {
         switch (key) {
             case SYSTEM_KEY -> {

--- a/src/main/java/com/sethhaskellcondie/thegamepensieveapi/domain/entity/EntityRepositoryAbstract.java
+++ b/src/main/java/com/sethhaskellcondie/thegamepensieveapi/domain/entity/EntityRepositoryAbstract.java
@@ -29,7 +29,6 @@ public abstract class EntityRepositoryAbstract<T extends Entity<RequestDto, Resp
     private final CustomFieldValueRepository customFieldValueRepository;
     private final CustomFieldRepository customFieldRepository;
     private final String baseQuery;
-    private final String baseQueryJoinCustomFieldValues;
     private final String baseQueryWhereDeletedAtIsNotNull;
     private final String baseQueryIncludeDeleted;
     private final String entityKey;
@@ -42,26 +41,24 @@ public abstract class EntityRepositoryAbstract<T extends Entity<RequestDto, Resp
         this.customFieldValueRepository = new CustomFieldValueRepository(jdbcTemplate);
         this.customFieldRepository = new CustomFieldRepository(jdbcTemplate);
         this.baseQuery = this.getBaseQueryExcludeDeleted();
-        this.baseQueryJoinCustomFieldValues = this.getBaseQueryJoinCustomFieldValues();
         this.baseQueryWhereDeletedAtIsNotNull = this.getBaseQueryWhereIsDeleted();
-        this.baseQueryIncludeDeleted = this.getBaseQuery();
+        this.baseQueryIncludeDeleted = this.getBaseQuery(true);
         this.entityKey = this.getEntityKey();
         this.rowMapper = this.getRowMapper();
     }
 
     //DO NOT end the base queries with a ';' they will be appended
-    protected abstract String getBaseQuery();
+    // Pass includeWhereClause=true to get "SELECT … FROM table WHERE 1 = 1 " (for normal queries and queryById).
+    // Pass includeWhereClause=false to get "SELECT … FROM table" (for building multi-JOIN custom field queries).
+    protected abstract String getBaseQuery(boolean includeWhereClause);
     protected String getBaseQueryExcludeDeleted() {
-        return getBaseQuery() + " AND deleted_at IS NULL ";
+        return getBaseQuery(true) + " AND deleted_at IS NULL ";
     }
 
     protected String getBaseQueryWhereIsDeleted() {
-        return getBaseQuery() + " AND deleted_at IS NOT NULL ";
+        return getBaseQuery(true) + " AND deleted_at IS NOT NULL ";
     }
 
-    // Returns only the SELECT … FROM {table} clause (no JOINs, no WHERE).
-    // Used by getWithFilters() to build a dynamic multi-JOIN query when custom field filters are present.
-    protected abstract String getBaseQueryJoinCustomFieldValues();
     protected abstract String getEntityKey();
     protected abstract RowMapper<T> getRowMapper();
 
@@ -112,7 +109,7 @@ public abstract class EntityRepositoryAbstract<T extends Entity<RequestDto, Resp
 
     private String buildQueryWithCustomFieldJoins(int count) {
         String tableName = Keychain.getTableAliasByKey(entityKey);
-        StringBuilder builder = new StringBuilder(baseQueryJoinCustomFieldValues);
+        StringBuilder builder = new StringBuilder(getBaseQuery(false));
         for (int i = 1; i <= count; i++) {
             builder.append(" JOIN custom_field_values AS values").append(i)
               .append(" ON ").append(tableName).append(".id = values").append(i).append(".entity_id")

--- a/src/main/java/com/sethhaskellcondie/thegamepensieveapi/domain/entity/EntityRepositoryAbstract.java
+++ b/src/main/java/com/sethhaskellcondie/thegamepensieveapi/domain/entity/EntityRepositoryAbstract.java
@@ -1,5 +1,6 @@
 package com.sethhaskellcondie.thegamepensieveapi.domain.entity;
 
+import com.sethhaskellcondie.thegamepensieveapi.domain.Keychain;
 import com.sethhaskellcondie.thegamepensieveapi.domain.customfield.CustomField;
 import com.sethhaskellcondie.thegamepensieveapi.domain.customfield.CustomFieldRepository;
 import com.sethhaskellcondie.thegamepensieveapi.domain.customfield.CustomFieldValueRepository;
@@ -57,6 +58,9 @@ public abstract class EntityRepositoryAbstract<T extends Entity<RequestDto, Resp
     protected String getBaseQueryWhereIsDeleted() {
         return getBaseQuery() + " AND deleted_at IS NOT NULL ";
     }
+
+    // Returns only the SELECT … FROM {table} clause (no JOINs, no WHERE).
+    // Used by getWithFilters() to build a dynamic multi-JOIN query when custom field filters are present.
     protected abstract String getBaseQueryJoinCustomFieldValues();
     protected abstract String getEntityKey();
     protected abstract RowMapper<T> getRowMapper();
@@ -92,15 +96,33 @@ public abstract class EntityRepositoryAbstract<T extends Entity<RequestDto, Resp
         filters = FilterService.validateAndOrderFilters(filters, customFields);
         final List<String> whereStatements = FilterService.formatWhereStatements(filters);
         final List<Object> operands = FilterService.formatOperands(filters);
-        String sql = baseQuery + String.join(" ", whereStatements);
-        if (filters.stream().anyMatch(Filter::isCustom)) {
-            sql = baseQueryJoinCustomFieldValues + String.join(" ", whereStatements);
+        long customFilterCount = filters.stream().filter(Filter::isCustom).count();
+        String sql;
+        if (customFilterCount == 0) {
+            sql = baseQuery + String.join(" ", whereStatements);
+        } else {
+            sql = buildQueryWithCustomFieldJoins((int) customFilterCount) + String.join(" ", whereStatements);
         }
         List<T> entities = jdbcTemplate.query(sql, rowMapper, operands.toArray());
         for (T entity: entities) {
             setCustomFieldsValuesForEntity(entity);
         }
         return entities;
+    }
+
+    private String buildQueryWithCustomFieldJoins(int count) {
+        String tableName = Keychain.getTableAliasByKey(entityKey);
+        StringBuilder builder = new StringBuilder(baseQueryJoinCustomFieldValues);
+        for (int i = 1; i <= count; i++) {
+            builder.append(" JOIN custom_field_values AS values").append(i)
+              .append(" ON ").append(tableName).append(".id = values").append(i).append(".entity_id")
+              .append(" AND values").append(i).append(".entity_key = '").append(entityKey).append("'");
+            builder.append(" JOIN custom_fields AS fields").append(i)
+              .append(" ON values").append(i).append(".custom_field_id = fields").append(i).append(".id")
+              .append(" AND fields").append(i).append(".deleted = false");
+        }
+        builder.append(" WHERE ").append(tableName).append(".deleted_at IS NULL");
+        return builder.toString();
     }
 
     @Override

--- a/src/main/java/com/sethhaskellcondie/thegamepensieveapi/domain/entity/EntityRepositoryAbstract.java
+++ b/src/main/java/com/sethhaskellcondie/thegamepensieveapi/domain/entity/EntityRepositoryAbstract.java
@@ -48,8 +48,6 @@ public abstract class EntityRepositoryAbstract<T extends Entity<RequestDto, Resp
     }
 
     //DO NOT end the base queries with a ';' they will be appended
-    // Pass includeWhereClause=true to get "SELECT … FROM table WHERE 1 = 1 " (for normal queries and queryById).
-    // Pass includeWhereClause=false to get "SELECT … FROM table" (for building multi-JOIN custom field queries).
     protected abstract String getBaseQuery(boolean includeWhereClause);
     protected String getBaseQueryExcludeDeleted() {
         return getBaseQuery(true) + " AND deleted_at IS NULL ";

--- a/src/main/java/com/sethhaskellcondie/thegamepensieveapi/domain/entity/boardgame/BoardGameRepository.java
+++ b/src/main/java/com/sethhaskellcondie/thegamepensieveapi/domain/entity/boardgame/BoardGameRepository.java
@@ -35,14 +35,10 @@ public class BoardGameRepository extends EntityRepositoryAbstract<BoardGame, Boa
 
     @Override
     protected String getBaseQueryJoinCustomFieldValues() {
-        return String.format("""
+        return """
                 SELECT board_games.id, board_games.title, board_games.created_at, board_games.updated_at, board_games.deleted_at
                 FROM board_games
-                JOIN custom_field_values as values ON board_games.id = values.entity_id
-                          JOIN custom_fields as fields ON values.custom_field_id = fields.id
-                                   WHERE board_games.deleted_at IS NULL
-                                 AND values.entity_key = '%s'
-                """, Keychain.BOARD_GAME_KEY);
+                """;
     }
 
     @Override

--- a/src/main/java/com/sethhaskellcondie/thegamepensieveapi/domain/entity/boardgame/BoardGameRepository.java
+++ b/src/main/java/com/sethhaskellcondie/thegamepensieveapi/domain/entity/boardgame/BoardGameRepository.java
@@ -29,16 +29,11 @@ public class BoardGameRepository extends EntityRepositoryAbstract<BoardGame, Boa
         return "SELECT board_games.id, board_games.title, board_games.created_at, board_games.updated_at, board_games.deleted_at";
     }
 
-    protected String getBaseQuery() {
-        return getSelectClause() + " FROM board_games WHERE 1 = 1 ";
-    }
-
-    @Override
-    protected String getBaseQueryJoinCustomFieldValues() {
-        return """
-                SELECT board_games.id, board_games.title, board_games.created_at, board_games.updated_at, board_games.deleted_at
-                FROM board_games
-                """;
+    protected String getBaseQuery(boolean includeWhereClause) {
+        if (includeWhereClause) {
+            return getSelectClause() + " FROM board_games WHERE 1 = 1 ";
+        }
+        return getSelectClause() + " FROM board_games";
     }
 
     @Override

--- a/src/main/java/com/sethhaskellcondie/thegamepensieveapi/domain/entity/boardgamebox/BoardGameBoxRepository.java
+++ b/src/main/java/com/sethhaskellcondie/thegamepensieveapi/domain/entity/boardgamebox/BoardGameBoxRepository.java
@@ -38,15 +38,11 @@ public class BoardGameBoxRepository extends EntityRepositoryAbstract<BoardGameBo
 
     @Override
     protected String getBaseQueryJoinCustomFieldValues() {
-        return String.format("""
+        return """
                 SELECT board_game_boxes.id, board_game_boxes.title, board_game_boxes.is_expansion, board_game_boxes.is_stand_alone, board_game_boxes.base_set_id, board_game_boxes.board_game_id,
                 board_game_boxes.created_at, board_game_boxes.updated_at, board_game_boxes.deleted_at
                 FROM board_game_boxes
-                JOIN custom_field_values as values ON board_game_boxes.id = values.entity_id
-                          JOIN custom_fields as fields ON values.custom_field_id = fields.id
-                                 WHERE board_game_boxes.deleted_at IS NULL
-                                 AND values.entity_key = '%s'
-                """, Keychain.BOARD_GAME_BOX_KEY);
+                """;
     }
 
     @Override

--- a/src/main/java/com/sethhaskellcondie/thegamepensieveapi/domain/entity/boardgamebox/BoardGameBoxRepository.java
+++ b/src/main/java/com/sethhaskellcondie/thegamepensieveapi/domain/entity/boardgamebox/BoardGameBoxRepository.java
@@ -32,17 +32,11 @@ public class BoardGameBoxRepository extends EntityRepositoryAbstract<BoardGameBo
                 + "board_game_boxes.created_at, board_game_boxes.updated_at, board_game_boxes.deleted_at";
     }
 
-    protected String getBaseQuery() {
-        return getSelectClause() + " FROM board_game_boxes WHERE 1 = 1 ";
-    }
-
-    @Override
-    protected String getBaseQueryJoinCustomFieldValues() {
-        return """
-                SELECT board_game_boxes.id, board_game_boxes.title, board_game_boxes.is_expansion, board_game_boxes.is_stand_alone, board_game_boxes.base_set_id, board_game_boxes.board_game_id,
-                board_game_boxes.created_at, board_game_boxes.updated_at, board_game_boxes.deleted_at
-                FROM board_game_boxes
-                """;
+    protected String getBaseQuery(boolean includeWhereClause) {
+        if (includeWhereClause) {
+            return getSelectClause() + " FROM board_game_boxes WHERE 1 = 1 ";
+        }
+        return getSelectClause() + " FROM board_game_boxes";
     }
 
     @Override

--- a/src/main/java/com/sethhaskellcondie/thegamepensieveapi/domain/entity/system/SystemRepository.java
+++ b/src/main/java/com/sethhaskellcondie/thegamepensieveapi/domain/entity/system/SystemRepository.java
@@ -40,19 +40,7 @@ public class SystemRepository extends EntityRepositoryAbstract<System, SystemReq
     }
 
     protected String getBaseQueryJoinCustomFieldValues() {
-        //in general the first row are the columns for the entity
-        //the second and third row are the columns for the custom field values and the custom fields they should always be the same
-        //then the remainder of the query is the same but fill in the property entity (systems)
-        return String.format("""
-                SELECT systems.id, systems.name, systems.generation, systems.handheld, systems.created_at, systems.updated_at, systems.deleted_at,
-                        values.custom_field_id, values.entity_key, values.value_text, values.value_number,
-                        fields.name as custom_field_name, fields.type as custom_field_type
-                    FROM systems
-                    JOIN custom_field_values as values ON systems.id = values.entity_id
-                    JOIN custom_fields as fields ON values.custom_field_id = fields.id
-                    WHERE systems.deleted_at IS NULL
-                    AND values.entity_key = '%s'
-            """, Keychain.SYSTEM_KEY);
+        return "SELECT systems.id, systems.name, systems.generation, systems.handheld, systems.created_at, systems.updated_at, systems.deleted_at FROM systems";
     }
 
     protected String getEntityKey() {

--- a/src/main/java/com/sethhaskellcondie/thegamepensieveapi/domain/entity/system/SystemRepository.java
+++ b/src/main/java/com/sethhaskellcondie/thegamepensieveapi/domain/entity/system/SystemRepository.java
@@ -35,12 +35,11 @@ public class SystemRepository extends EntityRepositoryAbstract<System, SystemReq
         return "SELECT systems.id, systems.name, systems.generation, systems.handheld, systems.created_at, systems.updated_at, systems.deleted_at ";
     }
 
-    protected String getBaseQuery() {
-        return getSelectClause() + " FROM systems WHERE 1 = 1 ";
-    }
-
-    protected String getBaseQueryJoinCustomFieldValues() {
-        return "SELECT systems.id, systems.name, systems.generation, systems.handheld, systems.created_at, systems.updated_at, systems.deleted_at FROM systems";
+    protected String getBaseQuery(boolean includeWhereClause) {
+        if (includeWhereClause) {
+            return getSelectClause() + " FROM systems WHERE 1 = 1 ";
+        }
+        return getSelectClause() + " FROM systems";
     }
 
     protected String getEntityKey() {

--- a/src/main/java/com/sethhaskellcondie/thegamepensieveapi/domain/entity/toy/ToyRepository.java
+++ b/src/main/java/com/sethhaskellcondie/thegamepensieveapi/domain/entity/toy/ToyRepository.java
@@ -34,16 +34,7 @@ public class ToyRepository extends EntityRepositoryAbstract<Toy, ToyRequestDto, 
     }
 
     protected String getBaseQueryJoinCustomFieldValues() {
-        return String.format("""
-            SELECT toys.id, toys.name, toys.set, toys.created_at, toys.updated_at, toys.deleted_at,
-               values.custom_field_id, values.entity_key, values.value_text, values.value_number,
-               fields.name as custom_field_name, fields.type as custom_field_type
-            FROM toys
-            JOIN custom_field_values as values ON toys.id = values.entity_id
-            JOIN custom_fields as fields ON values.custom_field_id = fields.id
-            WHERE toys.deleted_at IS NULL
-            AND values.entity_key = '%s'
-            """, Keychain.TOY_KEY);
+        return "SELECT toys.id, toys.name, toys.set, toys.created_at, toys.updated_at, toys.deleted_at FROM toys";
     }
 
     protected String getEntityKey() {

--- a/src/main/java/com/sethhaskellcondie/thegamepensieveapi/domain/entity/toy/ToyRepository.java
+++ b/src/main/java/com/sethhaskellcondie/thegamepensieveapi/domain/entity/toy/ToyRepository.java
@@ -29,12 +29,11 @@ public class ToyRepository extends EntityRepositoryAbstract<Toy, ToyRequestDto, 
         return "SELECT toys.id, toys.name, toys.set, toys.created_at, toys.updated_at, toys.deleted_at ";
     }
 
-    protected String getBaseQuery() {
-        return getSelectClause() + " FROM toys WHERE 1 = 1 ";
-    }
-
-    protected String getBaseQueryJoinCustomFieldValues() {
-        return "SELECT toys.id, toys.name, toys.set, toys.created_at, toys.updated_at, toys.deleted_at FROM toys";
+    protected String getBaseQuery(boolean includeWhereClause) {
+        if (includeWhereClause) {
+            return getSelectClause() + " FROM toys WHERE 1 = 1 ";
+        }
+        return getSelectClause() + " FROM toys";
     }
 
     protected String getEntityKey() {

--- a/src/main/java/com/sethhaskellcondie/thegamepensieveapi/domain/entity/videogame/VideoGameRepository.java
+++ b/src/main/java/com/sethhaskellcondie/thegamepensieveapi/domain/entity/videogame/VideoGameRepository.java
@@ -39,15 +39,11 @@ public class VideoGameRepository extends EntityRepositoryAbstract<VideoGame, Vid
 
     @Override
     protected String getBaseQueryJoinCustomFieldValues() {
-        return String.format("""
+        return """
                 SELECT video_games.id, video_games.title, video_games.system_id,
                        video_games.created_at, video_games.updated_at, video_games.deleted_at
-                        FROM video_games
-                        JOIN custom_field_values as values ON video_games.id = values.entity_id
-                          JOIN custom_fields as fields ON values.custom_field_id = fields.id
-                                   WHERE video_games.deleted_at IS NULL
-                                 AND values.entity_key = '%s'
-                """, Keychain.VIDEO_GAME_KEY);
+                FROM video_games
+                """;
     }
 
     @Override

--- a/src/main/java/com/sethhaskellcondie/thegamepensieveapi/domain/entity/videogame/VideoGameRepository.java
+++ b/src/main/java/com/sethhaskellcondie/thegamepensieveapi/domain/entity/videogame/VideoGameRepository.java
@@ -33,17 +33,11 @@ public class VideoGameRepository extends EntityRepositoryAbstract<VideoGame, Vid
         return "SELECT video_games.id, video_games.title, video_games.system_id, video_games.created_at, video_games.updated_at, video_games.deleted_at ";
     }
 
-    protected String getBaseQuery() {
-        return getSelectClause() + " FROM video_games WHERE 1 = 1 ";
-    }
-
-    @Override
-    protected String getBaseQueryJoinCustomFieldValues() {
-        return """
-                SELECT video_games.id, video_games.title, video_games.system_id,
-                       video_games.created_at, video_games.updated_at, video_games.deleted_at
-                FROM video_games
-                """;
+    protected String getBaseQuery(boolean includeWhereClause) {
+        if (includeWhereClause) {
+            return getSelectClause() + " FROM video_games WHERE 1 = 1 ";
+        }
+        return getSelectClause() + " FROM video_games";
     }
 
     @Override

--- a/src/main/java/com/sethhaskellcondie/thegamepensieveapi/domain/entity/videogamebox/VideoGameBoxRepository.java
+++ b/src/main/java/com/sethhaskellcondie/thegamepensieveapi/domain/entity/videogamebox/VideoGameBoxRepository.java
@@ -44,15 +44,11 @@ public class VideoGameBoxRepository extends EntityRepositoryAbstract<VideoGameBo
 
     @Override
     protected String getBaseQueryJoinCustomFieldValues() {
-        return String.format("""
+        return """
                 SELECT video_game_boxes.id, video_game_boxes.title, video_game_boxes.system_id, video_game_boxes.is_physical, video_game_boxes.is_collection,
                 video_game_boxes.created_at, video_game_boxes.updated_at, video_game_boxes.deleted_at
                 FROM video_game_boxes
-                JOIN custom_field_values as values ON video_game_boxes.id = values.entity_id
-                JOIN custom_fields as fields ON values.custom_field_id = fields.id
-                WHERE video_game_boxes.deleted_at IS NULL
-                AND values.entity_key = '%s'
-                """, Keychain.VIDEO_GAME_BOX_KEY);
+                """;
     }
 
     @Override

--- a/src/main/java/com/sethhaskellcondie/thegamepensieveapi/domain/entity/videogamebox/VideoGameBoxRepository.java
+++ b/src/main/java/com/sethhaskellcondie/thegamepensieveapi/domain/entity/videogamebox/VideoGameBoxRepository.java
@@ -35,20 +35,15 @@ public class VideoGameBoxRepository extends EntityRepositoryAbstract<VideoGameBo
     }
 
     private String getSelectClause() {
-        return "SELECT id, title, system_id, is_physical, is_collection, created_at, updated_at, deleted_at ";
+        return "SELECT video_game_boxes.id, video_game_boxes.title, video_game_boxes.system_id, video_game_boxes.is_physical, video_game_boxes.is_collection, "
+                + "video_game_boxes.created_at, video_game_boxes.updated_at, video_game_boxes.deleted_at ";
     }
 
-    protected String getBaseQuery() {
-        return getSelectClause() + " FROM video_game_boxes WHERE 1 = 1 ";
-    }
-
-    @Override
-    protected String getBaseQueryJoinCustomFieldValues() {
-        return """
-                SELECT video_game_boxes.id, video_game_boxes.title, video_game_boxes.system_id, video_game_boxes.is_physical, video_game_boxes.is_collection,
-                video_game_boxes.created_at, video_game_boxes.updated_at, video_game_boxes.deleted_at
-                FROM video_game_boxes
-                """;
+    protected String getBaseQuery(boolean includeWhereClause) {
+        if (includeWhereClause) {
+            return getSelectClause() + " FROM video_game_boxes WHERE 1 = 1 ";
+        }
+        return getSelectClause() + " FROM video_game_boxes";
     }
 
     @Override

--- a/src/main/java/com/sethhaskellcondie/thegamepensieveapi/domain/filter/FilterService.java
+++ b/src/main/java/com/sethhaskellcondie/thegamepensieveapi/domain/filter/FilterService.java
@@ -338,11 +338,16 @@ public class FilterService {
 
     public static List<String> formatWhereStatements(List<Filter> filters) {
         List<String> whereStatements = new ArrayList<>();
+        int customFieldIndex = 1;
         for (Filter filter : filters) {
             if (filter.isCustom()) {
-                //The table alias for custom_fields is always 'fields' as setup in each EntityRepository getBaseQueryJoinCustomFieldValues();
-                whereStatements.add(" AND fields.name = '" + filter.getField() + "'");
-                whereStatements.add(getCustomFilterWhereStatement(filter));
+                // Each custom field filter gets its own indexed JOIN alias (fields1/values1, fields2/values2, …)
+                // so that multiple custom field filters don't contradict each other in the WHERE clause.
+                String fieldsAlias = "fields" + customFieldIndex;
+                String valuesAlias = "values" + customFieldIndex;
+                whereStatements.add(" AND " + fieldsAlias + ".name = '" + filter.getField() + "'");
+                whereStatements.add(getCustomFilterWhereStatement(filter, valuesAlias));
+                customFieldIndex++;
             } else {
                 whereStatements.add(getWhereStatement(filter));
             }
@@ -350,30 +355,29 @@ public class FilterService {
         return whereStatements;
     }
 
-    private static String getCustomFilterWhereStatement(Filter filter) {
+    private static String getCustomFilterWhereStatement(Filter filter, String valuesAlias) {
         final String whereStatement;
-        //The table alias for custom_field_values is always 'values' as setup in each EntityRepository getBaseQueryJoinCustomFieldValues();
         switch (filter.getType()) {
             case CustomField.TYPE_TEXT, CustomField.TYPE_BOOLEAN -> {
                 switch (filter.getOperator()) {
-                    case OPERATOR_EQUALS -> whereStatement = " AND values.value_text = ?";
-                    case OPERATOR_NOT_EQUALS -> whereStatement = " AND values.value_text <> ?";
-                    case OPERATOR_CONTAINS, OPERATOR_STARTS_WITH, OPERATOR_ENDS_WITH -> whereStatement = " AND values.value_text LIKE ?";
-                    case OPERATOR_ORDER_BY -> whereStatement = " ORDER BY values.value_text ASC";
-                    case OPERATOR_ORDER_BY_DESC -> whereStatement = " ORDER BY values.value_text DESC";
+                    case OPERATOR_EQUALS -> whereStatement = " AND " + valuesAlias + ".value_text = ?";
+                    case OPERATOR_NOT_EQUALS -> whereStatement = " AND " + valuesAlias + ".value_text <> ?";
+                    case OPERATOR_CONTAINS, OPERATOR_STARTS_WITH, OPERATOR_ENDS_WITH -> whereStatement = " AND " + valuesAlias + ".value_text LIKE ?";
+                    case OPERATOR_ORDER_BY -> whereStatement = " ORDER BY " + valuesAlias + ".value_text ASC";
+                    case OPERATOR_ORDER_BY_DESC -> whereStatement = " ORDER BY " + valuesAlias + ".value_text DESC";
                     default -> whereStatement = "";
                 }
             }
             case CustomField.TYPE_NUMBER -> {
                 switch (filter.getOperator()) {
-                    case OPERATOR_EQUALS -> whereStatement = " AND values.value_number = ?";
-                    case OPERATOR_NOT_EQUALS -> whereStatement = " AND values.value_number <> ?";
-                    case OPERATOR_GREATER_THAN -> whereStatement = " AND values.value_number > ?";
-                    case OPERATOR_LESS_THAN -> whereStatement = " AND values.value_number < ?";
-                    case OPERATOR_GREATER_THAN_EQUAL_TO -> whereStatement = " AND values.value_number >= ?";
-                    case OPERATOR_LESS_THAN_EQUAL_TO -> whereStatement = " AND values.value_number <= ?";
-                    case OPERATOR_ORDER_BY -> whereStatement = " ORDER BY values.value_number ASC";
-                    case OPERATOR_ORDER_BY_DESC -> whereStatement = " ORDER BY values.value_number DESC";
+                    case OPERATOR_EQUALS -> whereStatement = " AND " + valuesAlias + ".value_number = ?";
+                    case OPERATOR_NOT_EQUALS -> whereStatement = " AND " + valuesAlias + ".value_number <> ?";
+                    case OPERATOR_GREATER_THAN -> whereStatement = " AND " + valuesAlias + ".value_number > ?";
+                    case OPERATOR_LESS_THAN -> whereStatement = " AND " + valuesAlias + ".value_number < ?";
+                    case OPERATOR_GREATER_THAN_EQUAL_TO -> whereStatement = " AND " + valuesAlias + ".value_number >= ?";
+                    case OPERATOR_LESS_THAN_EQUAL_TO -> whereStatement = " AND " + valuesAlias + ".value_number <= ?";
+                    case OPERATOR_ORDER_BY -> whereStatement = " ORDER BY " + valuesAlias + ".value_number ASC";
+                    case OPERATOR_ORDER_BY_DESC -> whereStatement = " ORDER BY " + valuesAlias + ".value_number DESC";
                     default -> whereStatement = "";
                 }
             }

--- a/src/main/resources/application-filter-tests7.properties
+++ b/src/main/resources/application-filter-tests7.properties
@@ -1,0 +1,4 @@
+# the db settings here are used in DatasourceConfig.java
+# this kind of properties file will not work as a .yml file
+spring.test.database.replace=none
+spring.datasource.url=jdbc:tc:postgresql:16.2-alpine:///filter-tests7

--- a/src/test/java/com/sethhaskellcondie/thegamepensieveapi/domain/filter/GetWithFiltersMultipleCustomFieldFiltersTests.java
+++ b/src/test/java/com/sethhaskellcondie/thegamepensieveapi/domain/filter/GetWithFiltersMultipleCustomFieldFiltersTests.java
@@ -1,0 +1,125 @@
+package com.sethhaskellcondie.thegamepensieveapi.domain.filter;
+
+import com.sethhaskellcondie.thegamepensieveapi.domain.Keychain;
+import com.sethhaskellcondie.thegamepensieveapi.domain.customfield.CustomField;
+import com.sethhaskellcondie.thegamepensieveapi.domain.customfield.CustomFieldRepository;
+import com.sethhaskellcondie.thegamepensieveapi.domain.customfield.CustomFieldRequestDto;
+import com.sethhaskellcondie.thegamepensieveapi.domain.customfield.CustomFieldValue;
+import com.sethhaskellcondie.thegamepensieveapi.domain.entity.system.System;
+import com.sethhaskellcondie.thegamepensieveapi.domain.entity.system.SystemRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import com.sethhaskellcondie.thegamepensieveapi.domain.exceptions.ExceptionInvalidFilter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Verifies that getWithFilters() returns correct results when multiple custom field filters
+ * are combined in a single query. This was previously broken because the generated SQL used
+ * a single JOIN alias for all custom fields, making it impossible for a row to satisfy
+ * two different field name conditions simultaneously.
+ *
+ * Also verifies that soft-deleted custom fields are excluded from results.
+ */
+@JdbcTest
+@ActiveProfiles("filter-tests7")
+public class GetWithFiltersMultipleCustomFieldFiltersTests {
+
+    @Autowired
+    protected JdbcTemplate jdbcTemplate;
+    protected SystemRepository systemRepository;
+    protected CustomFieldRepository customFieldRepository;
+
+    @BeforeEach
+    public void setUp() {
+        systemRepository = new SystemRepository(jdbcTemplate);
+        customFieldRepository = new CustomFieldRepository(jdbcTemplate);
+    }
+
+    @Test
+    void testMultipleCustomFieldFiltersReturnCorrectResults() {
+        String maxPlayersFieldName = "Max Players";
+        final CustomField maxPlayersField = customFieldRepository.insertCustomField(
+                new CustomFieldRequestDto(maxPlayersFieldName, CustomField.TYPE_NUMBER, Keychain.SYSTEM_KEY));
+        String localMultiplayerFieldName = "Local Multiplayer";
+        final CustomField localMultiplayerField = customFieldRepository.insertCustomField(
+                new CustomFieldRequestDto(localMultiplayerFieldName, CustomField.TYPE_BOOLEAN, Keychain.SYSTEM_KEY));
+
+        CustomFieldValue maxPlayers1 = createCfValue(maxPlayersField, "1");
+        CustomFieldValue maxPlayers2 = createCfValue(maxPlayersField, "2");
+        CustomFieldValue maxPlayers4 = createCfValue(maxPlayersField, "4");
+        CustomFieldValue localMultiTrue = createCfValue(localMultiplayerField, "true");
+        CustomFieldValue localMultiFalse = createCfValue(localMultiplayerField, "false");
+
+        insertSystem("System 1", List.of(maxPlayers4, localMultiTrue)); //matches both
+        insertSystem("System 2", List.of(maxPlayers2, localMultiTrue)); //matches both
+        insertSystem("System 3", List.of(maxPlayers4, localMultiFalse)); //matches max players but not multiplayer
+        insertSystem("System 4", List.of(maxPlayers1, localMultiTrue)); //matches multiplayer but not max players
+        insertSystem("System 5", List.of(maxPlayers4)); // no multiplayer field
+        insertSystem("System 6", List.of(localMultiTrue)); // no max players field
+
+
+        final int expectedMaxPlayers = 4; // should return systems 1, 2, 3, 5
+        List<Filter> maxPlayersFilter = List.of(
+                new Filter(Keychain.SYSTEM_KEY, Filter.FIELD_TYPE_NUMBER, maxPlayersFieldName, Filter.OPERATOR_GREATER_THAN_EQUAL_TO, "2", true)
+        );
+        assertEquals(expectedMaxPlayers, systemRepository.getWithFilters(maxPlayersFilter).size(), "Single custom field number filter (>=2) should return 4 results.");
+
+        final int expectedMultiplayer = 4; // should return systems 1, 2, 4, 6
+        List<Filter> multiplayerFilter = List.of(
+                new Filter(Keychain.SYSTEM_KEY, Filter.FIELD_TYPE_BOOLEAN, localMultiplayerFieldName, Filter.OPERATOR_EQUALS, "true", true)
+        );
+        assertEquals(expectedMultiplayer, systemRepository.getWithFilters(multiplayerFilter).size(),
+                "Single custom field boolean filter (=true) should return 4 results.");
+
+        final int expectedCombined = 2; // should return only systems 1 and 2
+        List<Filter> combinedFilters = List.of(
+                new Filter(Keychain.SYSTEM_KEY, Filter.FIELD_TYPE_NUMBER, maxPlayersFieldName, Filter.OPERATOR_GREATER_THAN_EQUAL_TO, "2", true),
+                new Filter(Keychain.SYSTEM_KEY, Filter.FIELD_TYPE_BOOLEAN, localMultiplayerFieldName, Filter.OPERATOR_EQUALS, "true", true)
+        );
+        assertEquals(expectedCombined, systemRepository.getWithFilters(combinedFilters).size(),
+                "Combined custom field filters (max players >= 2 AND local multiplayer = true) should return exactly 2 results.");
+    }
+
+    @Test
+    void testDeletedCustomFieldsAreExcluded() {
+        final CustomField deletedField = customFieldRepository.insertCustomField(
+                new CustomFieldRequestDto("Deleted Field", CustomField.TYPE_NUMBER, Keychain.SYSTEM_KEY));
+        final CustomField activeField = customFieldRepository.insertCustomField(
+                new CustomFieldRequestDto("Active Field", CustomField.TYPE_NUMBER, Keychain.SYSTEM_KEY));
+
+        CustomFieldValue deletedFieldValue = createCfValue(deletedField, "42");
+        CustomFieldValue activeFieldValue = createCfValue(activeField, "42");
+        insertSystem("System With Deleted Field", List.of(deletedFieldValue, activeFieldValue));
+        customFieldRepository.deleteById(deletedField.id());
+
+
+        List<Filter> filterOnDeletedField = List.of(
+                new Filter(Keychain.SYSTEM_KEY, Filter.FIELD_TYPE_NUMBER, "Deleted Field", Filter.OPERATOR_EQUALS, "42", true)
+        );
+        assertThrows(ExceptionInvalidFilter.class, () -> systemRepository.getWithFilters(filterOnDeletedField),
+                "Filtering on a deleted custom field should throw ExceptionInvalidFilter since deleted fields are excluded from validation.");
+
+        List<Filter> filterOnActiveField = List.of(
+                new Filter(Keychain.SYSTEM_KEY, Filter.FIELD_TYPE_NUMBER, "Active Field", Filter.OPERATOR_EQUALS, "42", true)
+        );
+        assertEquals(1, systemRepository.getWithFilters(filterOnActiveField).size(),
+                "Filtering on an active custom field should return the matching system.");
+    }
+
+    private CustomFieldValue createCfValue(CustomField field, String value) {
+        return new CustomFieldValue(field.id(), field.name(), field.type(), value);
+    }
+
+    private void insertSystem(String name, List<CustomFieldValue> customFieldValues) {
+        systemRepository.insert(new System(null, name, 1, false, null, null, null, customFieldValues));
+    }
+}


### PR DESCRIPTION
 
  AND fields.name = 'Max Players'       AND values.value_number >= 2
  AND fields.name = 'Local Multiplayer' AND values.value_text = 'true'
  
  A single joined row can never satisfy two different fields.name conditions at once, so the query always returned empty. Additionally, soft-deleted custom fields were not excluded from query results.
  
  Fix
  
  Replaced the single hard-coded JOIN pair with dynamically generated, indexed JOIN pairs — one per custom field filter (values1/fields1, values2/fields2, etc.). Each JOIN includes AND fields{N}.deleted = false, fixing the
  deleted field exclusion at the same time.
  
  Refactoring
                                                                                                                                                                                                                                   
  While implementing the fix, two follow-on improvements were made to reduce duplication:                                                                                                                                          
                                                                                                                                                                                                                                   
  - Removed getBaseQueryJoinCustomFieldValues() from the abstract class and all 6 concrete repositories. The SELECT+FROM clause is now derived directly from getBaseQuery(false), a new boolean parameter that controls whether    
  WHERE 1 = 1 is appended.                                                                                                                                                                                                         
  - Updated VideoGameBoxRepository.getSelectClause() to use fully-qualified column names (video_game_boxes.id etc.), consistent with all other repositories, which is required to avoid ambiguous column references when JOIN      
  clauses are present.                                                                                                                                                                                                             
                                                                                                                                                                                                                                   
  Tests                                                                                                                                                                                                                            
                                                                                                                                                                                                                                   
  Added GetWithFiltersMultipleCustomFieldFiltersTests with two test cases:                                                                                                                                                         
  - Verifies that filtering on two custom fields simultaneously returns only the correct intersection of results (regression test for single-field filters included).                                                              
  - Verifies that filtering on a soft-deleted custom field throws ExceptionInvalidFilter, confirming deleted fields are properly excluded from the valid filter set.   